### PR TITLE
Add security scan workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,61 @@
+name: Security Scan
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  backend-dependency-check:
+    name: Backend Dependency Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Run OWASP Dependency Check
+        run: ./mvnw -B org.owasp:dependency-check-maven:check -DskipTests
+
+  frontend-npm-audit:
+    name: Frontend npm audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - name: Install dependencies
+        run: npm install --production --ignore-scripts
+      - name: Run npm audit
+        run: npm audit --audit-level=high

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This repository contains a full-stack **Survey App** built with:
 -  **Observability:** Logstash + Elasticsearch + Kibana + Grafana  
 -  **Monitoring** | Prometheus + Grafana (Latency, Error Rate, Traffic, Saturation) 
 -  **Stress tests with k6** (nightly via GitHub Actions)
-*  **Delivery:** GitHub Actions · Docker · Caddy reverse‑proxy  
+-  **Delivery:** GitHub Actions · Docker · Caddy reverse‑proxy
+-  **Security scanning** | OWASP Dependency Check and npm audit via GitHub Actions
 
 ###  Dev development
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run OWASP Dependency Check and npm audit
- document security scanning in README

## Testing
- `npm ci`
- `npx vitest run`
- `./mvnw test` *(fails: could not resolve spring-boot-starter-parent due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68401503acf08321b20fa74ef92095a9